### PR TITLE
dropdown 영광

### DIFF
--- a/practice/dropdown/c11g/dropdown.html
+++ b/practice/dropdown/c11g/dropdown.html
@@ -13,6 +13,7 @@ button[aria-haspopup="listbox"] { position: relative; padding: 5px 10px; width: 
 button[aria-haspopup="listbox"]::after {position: absolute;right: 5px;top: 10px;width: 0;height: 0;border: 8px solid transparent;border-top-color: currentColor;border-bottom: 0;content: ""; }
 button[aria-haspopup="listbox"][aria-expanded="true"]::after {position: absolute;right: 5px;top: 10px;width: 0;height: 0;border: 8px solid transparent;border-top: 0;border-bottom-color: currentColor;content: ""; }
 button[aria-haspopup="listbox"] + [role="listbox"] { position: absolute; margin: 0; width: 9.5em; max-height: 10em; border-top: 0; overflow-y: auto; }
+button[aria-haspopup="listbox"]:focus { background: rgba(0,0,0,.1); }
 button { font-size: inherit; }
 .hidden { display: none; }
 </style>

--- a/practice/dropdown/c11g/dropdown.html
+++ b/practice/dropdown/c11g/dropdown.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="X-UA-Compatible" content="ie=edge">
+<style>
+[role="listbox"] { margin: 1em 0 0; padding: 0; min-height: 18em; border: 1px solid #aaa; background: white; }
+[role="option"] { position: relative; display: block; padding: 0 1em 0 1.5em; line-height: 1.8em; }
+[role="option"].focused { background: #bde4ff; }
+[role="option"][aria-selected="true"]::before { position: absolute; left: 0.5em; content: "✓"; }
+button[aria-haspopup="listbox"] { position: relative; padding: 5px 10px; width: 150px; border-radius: 0; text-align: left; }
+button[aria-haspopup="listbox"]::after {position: absolute;right: 5px;top: 10px;width: 0;height: 0;border: 8px solid transparent;border-top-color: currentColor;border-bottom: 0;content: ""; }
+button[aria-haspopup="listbox"][aria-expanded="true"]::after {position: absolute;right: 5px;top: 10px;width: 0;height: 0;border: 8px solid transparent;border-top: 0;border-bottom-color: currentColor;content: ""; }
+button[aria-haspopup="listbox"] + [role="listbox"] { position: absolute; margin: 0; width: 9.5em; max-height: 10em; border-top: 0; overflow-y: auto; }
+button { font-size: inherit; }
+.hidden { display: none; }
+</style>
+<title>dropdown c11g</title>
+</head>
+<body>
+  <div id="exp_wrapper">
+    <button type="button"
+      aria-haspopup="listbox"
+      aria-labelledby="exp_elem exp_button"
+      id="exp_button">
+      Neptunium
+    </button>
+    <ul id="exp_elem_list"
+      tabindex="-1"
+      role="listbox"
+      aria-labelledby="exp_elem"
+      class="hidden">
+      <li id="exp_elem_Np" role="option">Neptunium</li>
+      <li id="exp_elem_Pu" role="option">Plutonium</li>
+      <li id="exp_elem_Am" role="option">Americium</li>
+      <li id="exp_elem_Cm" role="option">Curium</li>
+      <li id="exp_elem_Bk" role="option">Berkelium</li>
+      <li id="exp_elem_Cf" role="option">Californium</li>
+    </ul>
+  </div>
+<script src="dropdown.js"></script>
+<script>
+const dropdown = new Dropdown('#exp_wrapper');
+</script>
+</body>
+</html>

--- a/practice/dropdown/c11g/dropdown.html
+++ b/practice/dropdown/c11g/dropdown.html
@@ -39,8 +39,9 @@ button { font-size: inherit; }
       <li id="exp_elem_Cf" role="option">Californium</li>
     </ul>
   </div>
-<script src="dropdown.js"></script>
-<script>
+<script src="dropdown.js" type="module"></script>
+<script type="module">
+import Dropdown from './dropdown.js';
 const dropdown = new Dropdown('#exp_wrapper');
 </script>
 </body>

--- a/practice/dropdown/c11g/dropdown.js
+++ b/practice/dropdown/c11g/dropdown.js
@@ -6,28 +6,23 @@ class Dropdown {
     this.listbox = this.wrapper.querySelector(`[role='listbox']`);
     this.options = [...this.wrapper.querySelectorAll(`[role='option']`)];
     
-    // 선택된 옵션 index
+    // 선택된 옵션 초기화
     this.selectedIndex = 0;
-    this.keyMap = {
-      up: 38,
-      down: 40,
-      enter: 13,
-      esc: 27,
-    };
+    this.options[this.selectedIndex].classList.add('focused');
+    this.options[this.selectedIndex].setAttribute('aria-selected', true);
 
-    // add events
+    // 이벤트 등록
     this.addEvents();
   }
 
-  toggleExpanded() {
-    if (this.button.getAttribute('aria-expanded')) {
-      this.button.removeAttribute('aria-expanded');
-      this.listbox.classList.add('hidden');
-      this.button.focus();
-    } else {
-      this.button.setAttribute('aria-expanded', true);
-      this.listbox.classList.remove('hidden');
-    }
+  expand() {
+    this.button.setAttribute('aria-expanded', true);
+    this.listbox.classList.remove('hidden');
+  }
+  
+  collapse() {
+    this.button.removeAttribute('aria-expanded');
+    this.listbox.classList.add('hidden');
   }
 
   selectOption() {
@@ -49,43 +44,54 @@ class Dropdown {
     this.listbox.setAttribute('aria-activedescendant', currentOption.id);
   }
 
-  addEvents() {
-    this.button.addEventListener('click', () => {
-      console.log('button click')
-      this.toggleExpanded();
-      this.selectOption();
+  // handler
+  buttonClickHandler() {
+    if (this.button.getAttribute('aria-expanded')) {
+      this.collapse();
+      this.button.focus();
+    } else {
+      this.expand();
       this.listbox.focus();
-    });
+    }
+  }
 
-    this.listbox.addEventListener('click', e => {
-      if (e.target.getAttribute('role') !== 'option' || e.target.getAttribute('aria-selected')) return;
-      
-      this.selectedIndex = this.options.indexOf(e.target);
-      this.selectOption();
-    });
+  optionClickHandler(e) {
+    if (e.target.getAttribute('role') !== 'option' || e.target.getAttribute('aria-selected')) return;
+    this.selectedIndex = this.options.indexOf(e.target);
+    this.selectOption();
+  }
 
-    this.listbox.addEventListener('keydown', e => {
-      switch ( e.keyCode ) {
-        case this.keyMap.up:
-          if (this.selectedIndex <= 0) return;
-          this.selectedIndex--;
-        break;
-        case this.keyMap.down:
-          if (this.selectedIndex >= this.options.length-1) return;
-          this.selectedIndex++;
-        break;
-        case this.keyMap.enter:
-        case this.keyMap.esc:
-          this.listbox.blur();
-          return;
-      }
-      this.selectOption();
-    });
+  optionKeyHandler(e) {
+    switch (e.keyCode) {
+      case 38: // up
+        if (this.selectedIndex <= 0) return;
+        this.selectedIndex--;
+        this.selectOption();
+      break;
+      case 40: // down
+        if (this.selectedIndex >= this.options.length-1) return;
+        this.selectedIndex++;
+        this.selectOption();
+      break;
+      case 13: // enter
+      case 27: // esc
+        e.preventDefault();
+        this.collapse();
+        this.button.focus();
+      break;
+    }
+  }
 
-    this.listbox.addEventListener('blur', () => {
-      console.log('blur')
-      this.toggleExpanded();
-    });
+  blurHander(e) {
+    if (e.relatedTarget === this.button) return;
+    this.collapse();
+  }
+
+  addEvents() {
+    this.button.addEventListener('click', () => this.buttonClickHandler());
+    this.listbox.addEventListener('click', e => this.optionClickHandler(e));
+    this.listbox.addEventListener('keydown', e => this.optionKeyHandler(e));
+    this.listbox.addEventListener('blur', e => this.blurHander(e));
   }
 }
 

--- a/practice/dropdown/c11g/dropdown.js
+++ b/practice/dropdown/c11g/dropdown.js
@@ -1,0 +1,58 @@
+class Dropdown {
+  constructor(element) {
+    // DOM 참조
+    this.wrapper = document.querySelector(element);
+    this.button = this.wrapper.querySelector('button');
+    this.listbox = this.wrapper.querySelector(`[role='listbox']`);
+    this.options = [...this.wrapper.querySelectorAll(`[role='option']`)];
+    
+    // 선택된 옵션 index
+    this.selectedIndex = 0;
+
+    // add events
+    this.addEvents();
+  }
+
+  toggleExpanded() {
+    if ( this.button.getAttribute('aria-expanded') ) {
+      this.button.removeAttribute('aria-expanded');
+      this.listbox.classList.add('hidden');
+    } else {
+      this.button.setAttribute('aria-expanded', true);
+      this.listbox.classList.remove('hidden');
+    }
+  }
+
+  selectOption() {
+    const currentOption = this.options[this.selectedIndex];
+    
+    this.options.some(option => {
+      if ( option.getAttribute('aria-selected') ) {
+        option.removeAttribute('aria-selected');
+        option.classList.remove('focused');
+        return true;
+      }
+    });
+    
+    currentOption.classList.add('focused');
+    currentOption.setAttribute('aria-selected', true);
+
+    this.button.textContent = currentOption.textContent;
+    this.listbox.setAttribute('aria-activedescendant', currentOption.id);
+  }
+
+  addEvents() {
+    this.button.addEventListener('click', e => {
+      this.toggleExpanded();
+      this.listbox.focus();
+      this.selectOption();
+    });
+
+    this.listbox.addEventListener('click', e => {
+      if ( e.target.getAttribute('aria-selected') ) return;
+      const clikedOptionIndex = this.options.indexOf(e.target);
+      this.selectedIndex = clikedOptionIndex;
+      this.selectOption();
+    });
+  }
+}

--- a/practice/dropdown/c11g/dropdown.js
+++ b/practice/dropdown/c11g/dropdown.js
@@ -8,15 +8,22 @@ class Dropdown {
     
     // 선택된 옵션 index
     this.selectedIndex = 0;
+    this.keyMap = {
+      up: 38,
+      down: 40,
+      enter: 13,
+      esc: 27,
+    };
 
     // add events
     this.addEvents();
   }
 
   toggleExpanded() {
-    if ( this.button.getAttribute('aria-expanded') ) {
+    if (this.button.getAttribute('aria-expanded')) {
       this.button.removeAttribute('aria-expanded');
       this.listbox.classList.add('hidden');
+      this.button.focus();
     } else {
       this.button.setAttribute('aria-expanded', true);
       this.listbox.classList.remove('hidden');
@@ -26,8 +33,9 @@ class Dropdown {
   selectOption() {
     const currentOption = this.options[this.selectedIndex];
     
+    // 옵션을 순회하면서 기존에 선택된 옵션 해제
     this.options.some(option => {
-      if ( option.getAttribute('aria-selected') ) {
+      if (option.getAttribute('aria-selected')) {
         option.removeAttribute('aria-selected');
         option.classList.remove('focused');
         return true;
@@ -42,17 +50,43 @@ class Dropdown {
   }
 
   addEvents() {
-    this.button.addEventListener('click', e => {
+    this.button.addEventListener('click', () => {
+      console.log('button click')
       this.toggleExpanded();
-      this.listbox.focus();
       this.selectOption();
+      this.listbox.focus();
     });
 
     this.listbox.addEventListener('click', e => {
-      if ( e.target.getAttribute('aria-selected') ) return;
-      const clikedOptionIndex = this.options.indexOf(e.target);
-      this.selectedIndex = clikedOptionIndex;
+      if (e.target.getAttribute('role') !== 'option' || e.target.getAttribute('aria-selected')) return;
+      
+      this.selectedIndex = this.options.indexOf(e.target);
       this.selectOption();
+    });
+
+    this.listbox.addEventListener('keydown', e => {
+      switch ( e.keyCode ) {
+        case this.keyMap.up:
+          if (this.selectedIndex <= 0) return;
+          this.selectedIndex--;
+        break;
+        case this.keyMap.down:
+          if (this.selectedIndex >= this.options.length-1) return;
+          this.selectedIndex++;
+        break;
+        case this.keyMap.enter:
+        case this.keyMap.esc:
+          this.listbox.blur();
+          return;
+      }
+      this.selectOption();
+    });
+
+    this.listbox.addEventListener('blur', () => {
+      console.log('blur')
+      this.toggleExpanded();
     });
   }
 }
+
+export default Dropdown;


### PR DESCRIPTION
### 관련 이슈
resolved: #8  (여기에 이슈 번호를 적으면 해당 pr이 머지되면 이슈가 자동으로 closed 되요.)

**과제 설명**
- `Dropdown` 클래스로 작성했어요.
- 다수의 dropdown을 고려하여 `new Dropdown(wrapper 요소)`로 인스턴스를 만들어 독립적으로 동작
- dom은 스타일과의 분리를 위해서 `class`명이 아닌 `role`을 기준으로 참조
- `this.seletedIndex`를 기준으로 옵션 선택

**주요 함수**
- `expand()` / `collapse()`: `aria-expanded`와 `class` 값 변경
- `selectOption()`:
  - 옵션을 순회하면서 초기화하고
  - 선택한 옵션에는 `aria-selected`와 `class`값 추가
  - 텍스트 및 `aria-activedescendant` 변경
- `addEvents()`: 모든 이벤트에 핸들러 등록

**어려웠던 부분**
- 스펙 상 `#exp_button`에 클릭 이벤트로 펼침과 닫기를 모두 처리해야 했고, 닫기 조건 중 blur가 포함되어 있어서 아래의 경우에서 좀 어려웠어요. [(스펙링크)](https://github.com/DogsFoot/JAS-2020/tree/dropdown/practice/dropdown)
- 옵션이 펼쳐진 상태에서 `#exp_button`를 클릭하는 경우 2개의 이벤트가 발생하는데
  - `#exp_elem_list` blur: `collapse()` 실행
  - `#exp_button` click: `aria-expanded`를 판단해서 `collapse()` 또는 `expand()` 실행
- 순서가  `blur event` -> `collapse()` -> `click event` -> `expand()`가 되다보니, 옵션이 닫혔다가 바로 펼쳐지는... 그런 상황이 되버렸음. 처음에는 별도의 변수 flag를 사용하거나 아니면 `blur` 이벤트에서 `click` 이벤트를 막고 하면 되겠거니 했는데 생각보다 쉽지 않았네요 ㅠ(DOM, EVENT 어려워요 ㅠㅠ)
- 구글링 좀 해보니 이벤트 객체에 관련 타겟 요소라고 `relatedTarget`이 있는데(Mouse와 Focsu 이벤트에만 있는듯) 다행히도 포커스가 빠지는 이벤트에서는 그 포커스를 받는 요소를 `relatedTarget`으로 참조할 수 있어서 그걸로 분기처리를 했어요.
<a href="https://developer.mozilla.org/en-US/docs/Web/API/FocusEvent/relatedTarget" target="_blank">MDN 참고</a>