### PR TITLE
localstorage 기능 추가

### DIFF
--- a/practice/todolist/c11g/js/Renderer.js
+++ b/practice/todolist/c11g/js/Renderer.js
@@ -13,6 +13,7 @@ const Renderer = class {
     };
 
     this.addEvents();
+    this.render();
   }
 
   render() {
@@ -21,10 +22,15 @@ const Renderer = class {
       if (this.renderedTaskIDs.has(t.id)) return;
       this.renderedTaskIDs.add(t.id);
       const li = document.importNode(liTemplate.content, true).querySelector('li');
+      const [checkbox, span, button] = li.children;
       li.dataset.id = t.id;
-      li.querySelector('span').textContent = t.title;
-      li.querySelector('input').addEventListener('click', e => this.toggleHandler(e, t));
-      li.querySelector('button').addEventListener('click', _ => this.removeHandler(t));
+      span.textContent = t.title;
+      checkbox.checked = t.done;
+      t.done
+        ? checkbox.classList.add('done')
+        : checkbox.classList.remove('done');
+      checkbox.addEventListener('click', e => this.toggleHandler(e, t));
+      button.addEventListener('click', _ => this.removeHandler(t));
       ul.appendChild(li);
     });
   }
@@ -44,6 +50,7 @@ const Renderer = class {
     if (!title) return alert('제목을 입력해 주세요!');
     const task = new Task(title);
     this.todo.addTask(task);
+    this.todo.save();
     this.render();
     input.value = '';
     input.focus();
@@ -51,6 +58,7 @@ const Renderer = class {
 
   removeHandler(t) {
     this.todo.removeTask(t);
+    this.todo.save();
     this.renderedTaskIDs.delete(t.id);
     document.querySelector(`[data-id='${t.id}']`).remove();
   }
@@ -58,6 +66,7 @@ const Renderer = class {
   toggleHandler(e, t) {
     t.toggle();
     e.target.classList.toggle('done');
+    this.todo.save();
   }
 }
 

--- a/practice/todolist/c11g/js/Task.js
+++ b/practice/todolist/c11g/js/Task.js
@@ -1,7 +1,7 @@
 const Task = class {
-  constructor(title, done = false) {
-    this.id = Date.now();
+  constructor(title, id = Date.now(), done = false) {
     this.title = title;
+    this.id = id;
     this.done = done;
   }
 

--- a/practice/todolist/c11g/js/Todo.js
+++ b/practice/todolist/c11g/js/Todo.js
@@ -19,14 +19,11 @@ const Todo = class {
   }
 
   load() {
-    if (!localStorage.getItem(this.STORAGE_KEY)) return null;
-    const data = JSON.parse(localStorage.getItem(this.STORAGE_KEY));
-    const savedTask = data.reduce((tasks, t) => {
-      const task = new Task(t.title, t.id, t.done);
-      tasks.add(task);
-      return tasks;
-    }, new Set());
-    return savedTask;
+    return !localStorage.getItem(this.STORAGE_KEY)
+    ? null
+    : new Set(JSON.parse(localStorage.getItem(this.STORAGE_KEY),
+      (k, v) => (v.constructor === Object) ? new Task(v.title, v.id, v.done) : v
+    ));
   }
 }
 

--- a/practice/todolist/c11g/js/Todo.js
+++ b/practice/todolist/c11g/js/Todo.js
@@ -1,6 +1,9 @@
+import Task from './Task.js';
+
 const Todo = class {
   constructor() {
-    this.tasks = new Set();
+    this.STORAGE_KEY = 'tasks';
+    this.tasks = this.load() || new Set();
   }
 
   addTask(task) {
@@ -9,6 +12,21 @@ const Todo = class {
 
   removeTask(task) {
     this.tasks.delete(task);
+  }
+
+  save() {
+    localStorage.setItem(this.STORAGE_KEY, JSON.stringify([...this.tasks]));
+  }
+
+  load() {
+    if (!localStorage.getItem(this.STORAGE_KEY)) return null;
+    const data = JSON.parse(localStorage.getItem(this.STORAGE_KEY));
+    const savedTask = data.reduce((tasks, t) => {
+      const task = new Task(t.title, t.id, t.done);
+      tasks.add(task);
+      return tasks;
+    }, new Set());
+    return savedTask;
   }
 }
 

--- a/practice/todolist/c11g/todolist.html
+++ b/practice/todolist/c11g/todolist.html
@@ -20,6 +20,7 @@
   </style>
 </head>
 <body>
+<button type="button" onclick="localStorage.clear();location.reload()">Clear And Refresh</button>
 <div class="todo-wrap">
   <div class="todo-prompt">
     <input type="text" placeholder="Write a to do" class="todo-input">


### PR DESCRIPTION
관련 이슈: #48 

애초부터 `localStorage` 추가 부분을 염두에 두고 작업했기에, 처음에는 거의 수정없이 아주 금방 할줄 알았어요. 한 10분이면 될라나? 쉽게 생각했다가 `Set`타입의 `JSON.stringify`가 내 생각과는 달라서 의외로 고생했네요ㅎㅎ

**코드 변경 부분 설명**

1. `Task` class
    - 이전에는 `title`, `done`만 인자로 받도록 되어있고, `id`는 생성 시에 `Date.now()`로 자동으로 들어갔었는데요. `localStorage`에서 불러올 때, 저장된 `id`를 갖도록 하기 위해서 `id`도 인자로 받을 수 있도록 수정

2. `Todo` class
    - `constructor()`:`tasks`를 초기화(`tasks = load() || new Set()`)
    - `load()`
        1. `localStorage.getItem(KEY)`이 있는지 체크, 없으면 명시적으로 `null`을 반환
        2. `new Set(JSON.parse(KEY, reviver))`: reviver에서 객체를` Task` 인스턴스로 변환하여 받은 배열을 `Set`으로 반환
        2. ~~`localStorage.getItem(KEY)`: 배열 형태의 string~~
        3. ~~`JSON.parse()`: string을 배열로 만듬(`data`로 이름 붙임)~~
        4. ~~`data.reduce()`:  `data`를 순회하면서, `new Task()`로 `Task` 인스턴스를 만들어 `Set`에 추가해서 반환~~
    - `save()`
        1. `tasks`가 객체 타입이기 때문에 `JSON.stringify()`로 문자열로 변환 후 저장
        2. 주의할 점은, `Set`의 경우 배열과 달리 문자열로 변환 하면 `"{}"` 이런 형태로 변환되기 때문에, 먼저 배열로 변환 후 저장(`Set` -> `Array` -> `JSON.stringify`).

3. `Render` class
    - `constructor()`: 시작시 `render()` 호출
    - `render()`: 기존 `checked`와 `class` 토글 기능을  task의 `toggle()` 메서드에 의존했던 부분을 `render`에도 추가(저장된 `done`의 값에 따라 `checkd`, `class` 모두 save/load로 복원 되어야 하기 때문에)
    - `addHandler, removeHandler, toggleHandler`에 `save` 추가

4. 테스트 편의를 위해 HTML에 `localStorage.clear()` 버튼 추가
